### PR TITLE
fix an error when using a Path in open()

### DIFF
--- a/make_book.py
+++ b/make_book.py
@@ -77,7 +77,7 @@ class File(object):
             language = re.match(r".([^\n]*)", path.suffix).group(1)
 
         # Read the raw lines fromt the input file.
-        with open(path, "r") as input:
+        with path.open("r") as input:
             raw_lines = input.readlines()
 
         # Retrieve an iterator over all line object.


### PR DESCRIPTION
Fix for old python3. With my old python 3.5 i got : TypeError: invalid file: PosixPath('amp/eg-amp-rs.lv2/manifest.ttl')